### PR TITLE
SLING-7998 - The FeatureJSONReader doesn't report in which file it encountered an error when the location information is available

### DIFF
--- a/src/main/java/org/apache/sling/feature/io/json/FeatureJSONReader.java
+++ b/src/main/java/org/apache/sling/feature/io/json/FeatureJSONReader.java
@@ -27,6 +27,7 @@ import java.util.function.BiConsumer;
 
 import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.stream.JsonParsingException;
 
 import org.apache.felix.utils.resource.CapabilityImpl;
 import org.apache.felix.utils.resource.RequirementImpl;
@@ -55,7 +56,7 @@ public class FeatureJSONReader extends JSONReaderBase {
         try {
             final FeatureJSONReader mr = new FeatureJSONReader(location);
             return mr.readFeature(reader);
-        } catch (final IllegalStateException | IllegalArgumentException e) {
+        } catch (final IllegalStateException | IllegalArgumentException | JsonParsingException e) {
             throw new IOException(e);
         }
     }


### PR DESCRIPTION
* handle `javax.json.stream.JsonParsingException`