### PR TITLE
SLING-8027 - Malformed JSON when serialising "include" elements

### DIFF
--- a/src/main/java/org/apache/sling/feature/io/json/FeatureJSONWriter.java
+++ b/src/main/java/org/apache/sling/feature/io/json/FeatureJSONWriter.java
@@ -105,7 +105,7 @@ public class FeatureJSONWriter extends JSONWriterBase {
             writeList(generator, JSONConstants.FEATURE_BUNDLES, inc.getBundleRemovals());
             writeList(generator, JSONConstants.FEATURE_FRAMEWORK_PROPERTIES, inc.getFrameworkPropertiesRemovals());
 
-            generator.writeEnd();
+            generator.writeEnd().writeEnd();
         }
     }
 


### PR DESCRIPTION
close the open JSONConstants.FEATURE_INCLUDE element